### PR TITLE
Fixing serializable hash error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     apicasso (0.4.0)
       cancancan (~> 2.0)
       rails (> 5)
+      ransack
       swagger-blocks
       will_paginate (~> 3.1.0)
 
@@ -122,6 +123,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.1)
+    ransack (2.0.1)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.1)
@@ -174,4 +180,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/app/controllers/apicasso/crud_controller.rb
+++ b/app/controllers/apicasso/crud_controller.rb
@@ -129,7 +129,9 @@ module Apicasso
     # Selects a fieldset that should be returned, instead of all fields
     # from records.
     def select_fields
-      @records = @records.select(*params[:select].split(','))
+      params[:select].split(',').each do |p|
+        @records = @records.select(p) if @records.column_names.include?(p)
+      end
     end
 
     # Reordering of records which happens when receiving `params[:sort]`

--- a/lib/apicasso.rb
+++ b/lib/apicasso.rb
@@ -3,6 +3,7 @@
 require 'cancancan'
 require 'swagger/blocks'
 require 'ransack'
+require 'will_paginate/array'
 require 'will_paginate'
 require 'apicasso/version'
 require 'apicasso/engine'


### PR DESCRIPTION
In this commit was refactored the methods 'show_json' and 'include_relations' and was write 'include_options' to fix serializable hash error in 'index' and 'show' requests